### PR TITLE
:bug: Fix markdown link detection

### DIFF
--- a/client/src/components/Input/MarkdownEditor/MarkdownEditor.jsx
+++ b/client/src/components/Input/MarkdownEditor/MarkdownEditor.jsx
@@ -25,7 +25,7 @@ const MarkdownEditor = ({ content, onChange }) => {
       value={content}
       onTabChange={setTab}
       selectedTab={tab}
-      generateMarkdownPreview={md => Promise.resolve(markdown.showdown.makeHtml(md))}
+      generateMarkdownPreview={md => Promise.resolve(markdown.text(md))}
       onChange={onChange}
       commands={listCommands}
       l18n={intl('l18n')}

--- a/client/src/services/markdown.js
+++ b/client/src/services/markdown.js
@@ -18,10 +18,14 @@ class Markdown {
     return this.emoji(title)
   }
 
-  html(text) {
+  text(text) {
     text = this.emoji(text)
     text = this.removeEmTagInLink(text)
 
+    return this.showdown.makeHtml(text)
+  }
+
+  html(text) {
     return (
       <div className="mde-preview">
         <div
@@ -32,7 +36,7 @@ class Markdown {
             border: '0'
           }}
           dangerouslySetInnerHTML={{
-            __html: this.showdown.makeHtml(text)
+            __html: this.text(text)
           }}
         />
       </div>
@@ -63,9 +67,17 @@ class Markdown {
     const sanitize = txt => txt.replace(/<em>/g, '').replace(/<\/em>/g, '')
 
     text = text.replace(/(\[.*\]\()?(https?:\/\/\S*)/gim, (link, a, b) => {
-      if (a && b[b.length - 1] === ')') {
+      const endOfB = b.split('').reduce(
+        (acc, c, i) => {
+          if (acc.stack === 0) return acc
+          return { i, stack: acc.stack + (c === '(' ? 1 : c === ')' ? -1 : 0) }
+        },
+        { i: 0, stack: 1 }
+      )
+
+      if (a && endOfB.stack === 0) {
         // Means it's a markdown link
-        return a + sanitize(b)
+        return a + sanitize(b.substr(0, endOfB.i)) + b.substr(endOfB.i)
       }
 
       return `<a href="${sanitize(link)}" target="_blank" rel="noopener noreferrer">${link}</a>`


### PR DESCRIPTION
Fixes #203 

There was 2 problems:

1. We weren't using the same methods when rendering markdown in the editor and rendering markdown in the rest of the app.
2. Our way of detecting a markdown link was flawed. It was working on the assumption that there would be a whitespace after the markdown link.

Those two problems are now fixed.

Note: This bug is yet another example on why we need to add tests to this application (See #138)