### PR TITLE
:sparkles: disable answer email notification if the answerer is the asker

### DIFF
--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -71,6 +71,8 @@ module.exports = {
 
       algolia.updateNode(ctx, nodeId)
 
+      // Let's notify the user who asked the question, but only if they did not answer the
+      // question them-selves.
       if (answer.node.question.user.id !== answer.user.id) {
         mailgun.sendNewAnswer(ctx, nodeId)
       }

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -31,9 +31,17 @@ module.exports = {
           `
         {
           id
+          user {
+            id
+          }
           node {
             flags(where:{type:"unanswered"}) {
               id
+            }
+            question {
+              user {
+                id
+              }
             }
           }
         }
@@ -62,7 +70,10 @@ module.exports = {
       })
 
       algolia.updateNode(ctx, nodeId)
-      mailgun.sendNewAnswer(ctx, nodeId)
+
+      if (answer.node.question.user.id !== answer.user.id) {
+        mailgun.sendNewAnswer(ctx, nodeId)
+      }
 
       return ctx.prisma.query.answer(
         {


### PR DESCRIPTION
Thank you for maintaining FAQ!

This PR's goal is to fix #230 as simply as possible.

According to the Prisma GraphQL schema, a node might not have a question attached, therefore I might need to check for that in my condition (ie `answer.node.question && answer.node.question.user.id !== answer.user.id`). However I fail to see a case where an answer would be given for a node that has no question. What do you think?