### PR TITLE
:bug: fix crash in case of prisma error when answering

### DIFF
--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -41,7 +41,12 @@ module.exports = {
         )
       } catch (e) {
         // The error doesn't includes the error code, so we use the message
-        if (e.message.includes('NodeAnswer') && e.message.includes('violate')) {
+        if (
+          e.message &&
+          e.message.includes &&
+          e.message.includes('NodeAnswer') &&
+          e.message.includes('violate')
+        ) {
           throw new Error('Someone already answered this question! Refresh this page.')
         }
         throw e


### PR DESCRIPTION
While I was working on #238, I made a mistake in the GraphQL query located [here](https://github.com/zenika-open-source/FAQ/blob/master/server/src/resolvers/answer.js#L32-L39). More precisely, I asked for a field that did not exist. I got an error in my terminal, however, it was not about my mistake, it said `Could not read property includes of undefined`. It turns out the code that handles errors for this query is expecting the error to always have a field `message` that is an array, and crashes if it does not.

This PR makes the code verify those assumptions, so that any other type error can bubble-up correctly.