### PR TITLE
:bug: fix double server response when no configuration

### DIFF
--- a/server/src/middlewares/configuration.js
+++ b/server/src/middlewares/configuration.js
@@ -6,8 +6,9 @@ const getConfiguration = async (multiTenant, req, next) => {
     return
   }
 
-  await refreshConfiguration(tenant).catch(next)
-  next()
+  await refreshConfiguration(tenant)
+    .then(() => next())
+    .catch(err => next(err))
 }
 
 const refreshConfiguration = async tenant => {


### PR DESCRIPTION
Message d'erreur : ERR_HTTP_HEADERS_SENT
Cause de l'erreur : oubli de l'utilisation de la commande 'npm run new_service' à l'étape 6 du guide d'installation