### PR TITLE
👷 add ci parameter to force prisma deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
       - run:
           name: Deploy prisma
           working_directory: server/scripts/prisma_deploy_all/
-          command: node index.js <<#pipeline.parameters.prisma-deploy-force>>--force<</pipeline.parameters.prismaDeployForce>>
+          command: node index.js <<# pipeline.parameters.prisma-deploy-force >>--force<</ pipeline.parameters.prismaDeployForce >>
   app-deploy:
     parameters:
       clever-app-id:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@ version: 2.1
 orbs:
   node: circleci/node@5.1.0
 
+parameters:
+  prismaDeployForce:
+    type: boolean
+    default: false
+
 executors:
   clever-cloud-deployer:
     docker:
@@ -190,8 +195,14 @@ jobs:
       - run:
           name: Deploy prisma
           working_directory: server/scripts/prisma_deploy_all/
-          command: node index.js
-
+          command: |
+            if ${{ pipeline.parameters.prismaDeployForce }}; then
+              echo "Deploying prisma with --force"
+              node index.js --force
+            else
+              echo "Deploying prisma without --force"
+              node index.js
+            fi
   app-deploy:
     parameters:
       clever-app-id:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
       - run:
           name: Deploy prisma
           working_directory: server/scripts/prisma_deploy_all/
-          command: node index.js <<# pipeline.parameters.prisma-deploy-force >>--force<</ pipeline.parameters.prismaDeployForce >>
+          command: node index.js <<# pipeline.parameters.prisma-deploy-force >>--force<</ pipeline.parameters.prisma-deploy-force >>
   app-deploy:
     parameters:
       clever-app-id:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   node: circleci/node@5.1.0
 
 parameters:
-  prismaDeployForce:
+  prisma-deploy-force:
     type: boolean
     default: false
 
@@ -195,14 +195,7 @@ jobs:
       - run:
           name: Deploy prisma
           working_directory: server/scripts/prisma_deploy_all/
-          command: |
-            if ${{ pipeline.parameters.prismaDeployForce }}; then
-              echo "Deploying prisma with --force"
-              node index.js --force
-            else
-              echo "Deploying prisma without --force"
-              node index.js
-            fi
+          command: node index.js <<#pipeline.parameters.prismaDeployForce>>--force<</pipeline.parameters.prismaDeployForce>>
   app-deploy:
     parameters:
       clever-app-id:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
       - run:
           name: Deploy prisma
           working_directory: server/scripts/prisma_deploy_all/
-          command: node index.js <<#pipeline.parameters.prismaDeployForce>>--force<</pipeline.parameters.prismaDeployForce>>
+          command: node index.js <<#pipeline.parameters.prisma-deploy-force>>--force<</pipeline.parameters.prismaDeployForce>>
   app-deploy:
     parameters:
       clever-app-id:


### PR DESCRIPTION
Add a parameter to the CircleCI pipeline that controls if `prisma deploy` should be run with the `--force` option. This can be useful when a data model migration is destructive.