### PR TITLE
🛠️ leverage front-end server proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ executors:
           ALGOLIA_APP_ID: M0NJ0PGAH1
           DISABLE_AUTH: true
           REACT_APP_DISABLE_AUTH: true
-          REACT_APP_GRAPHQL_ENDPOINT: http://localhost:4000/gql
-          REACT_APP_REST_ENDPOINT: http://localhost:4000/rest
+          REACT_APP_GRAPHQL_ENDPOINT: /gql
+          REACT_APP_REST_ENDPOINT: /rest
           REACT_APP_PRISMA_SERVICE: default/default
           REACT_APP_FAQ_URL: faq.team
       - image: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,6 @@ executors:
           ALGOLIA_APP_ID: M0NJ0PGAH1
           DISABLE_AUTH: true
           REACT_APP_DISABLE_AUTH: true
-          REACT_APP_GRAPHQL_ENDPOINT: /gql
-          REACT_APP_REST_ENDPOINT: /rest
           REACT_APP_PRISMA_SERVICE: default/default
           REACT_APP_FAQ_URL: faq.team
       - image: postgres

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "faq_client",
   "version": "1.0.0",
   "private": true,
+  "proxy": "http://localhost:4000",
   "dependencies": {
     "@apollo/react-hooks": "^3.1.3",
     "algoliasearch": "^3.35.1",

--- a/client/src/helpers/safeFetch.js
+++ b/client/src/helpers/safeFetch.js
@@ -1,7 +1,7 @@
 import routing from 'services/routing'
 
 export default async function safeFetch(path) {
-  const response = await fetch((process.env.REACT_APP_REST_ENDPOINT || '/rest') + '/' + path, {
+  const response = await fetch('/rest/' + path, {
     headers: { 'prisma-service': routing.getPrismaService() }
   })
 

--- a/client/src/helpers/safeFetch.js
+++ b/client/src/helpers/safeFetch.js
@@ -1,7 +1,7 @@
 import routing from 'services/routing'
 
 export default async function safeFetch(path) {
-  const response = await fetch('/rest/' + path, {
+  const response = await fetch(process.env.REACT_APP_REST_ENDPOINT + '/' + path, {
     headers: { 'prisma-service': routing.getPrismaService() }
   })
 

--- a/client/src/helpers/safeFetch.js
+++ b/client/src/helpers/safeFetch.js
@@ -1,7 +1,7 @@
 import routing from 'services/routing'
 
 export default async function safeFetch(path) {
-  const response = await fetch(process.env.REACT_APP_REST_ENDPOINT + '/' + path, {
+  const response = await fetch((process.env.REACT_APP_REST_ENDPOINT || '/rest') + '/' + path, {
     headers: { 'prisma-service': routing.getPrismaService() }
   })
 

--- a/client/src/services/apollo.js
+++ b/client/src/services/apollo.js
@@ -40,7 +40,7 @@ const apollo = new ApolloClient({
       }
     }),
     new HttpLink({
-      uri: process.env.REACT_APP_GRAPHQL_ENDPOINT
+      uri: process.env.REACT_APP_GRAPHQL_ENDPOINT || '/gql'
     })
   ]),
   cache: apolloCache,

--- a/client/src/services/apollo.js
+++ b/client/src/services/apollo.js
@@ -40,7 +40,7 @@ const apollo = new ApolloClient({
       }
     }),
     new HttpLink({
-      uri: '/gql'
+      uri: process.env.REACT_APP_GRAPHQL_ENDPOINT
     })
   ]),
   cache: apolloCache,

--- a/client/src/services/apollo.js
+++ b/client/src/services/apollo.js
@@ -40,7 +40,7 @@ const apollo = new ApolloClient({
       }
     }),
     new HttpLink({
-      uri: process.env.REACT_APP_GRAPHQL_ENDPOINT || '/gql'
+      uri: '/gql'
     })
   ]),
   cache: apolloCache,


### PR DESCRIPTION
Leverages the proxy feature from create-react-app instead of relying of required env vars and CORS for API requests.