### PR TITLE
🚑 fix static asset serving in production

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -64,7 +64,7 @@ if (process.env.NODE_ENV === 'production') {
 
   server.express.use(secure)
 
-  const staticPaths = ['static', 'img', '.well-known', 'manifest.json', 'robot.txt']
+  const staticPaths = ['assets', 'img', '.well-known', 'manifest.json', 'robot.txt']
 
   staticPaths.map(path => server.express.use('/' + path, express.static(frontPath + '/' + path)))
 


### PR DESCRIPTION
Vite changed the folder of built assets (CSS and JS files) from `static` to `assets` (see #346). However the production server treated `static` specially as a folder where it should not serve `index.html`. As a result, the server served `index.html` for all files located in `assets`, and assets could not be served in production. This fix adds `assets` to the list of files and folders that are treated specially by the server (in place of `static`).