### PR TITLE
:sparkles: Save and show the certified version of an answer

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,7 @@
         "babel-runtime": "^6.26.0",
         "classnames": "^2.2.5",
         "copy-to-clipboard": "^3.2.0",
-        "date-fns": "^1.29.0",
+        "date-fns": "^2.30.0",
         "eslint-config-react-app": "^7.0.1",
         "graphql": "^14.7.0",
         "graphql-tag": "^2.8.0",
@@ -3846,9 +3846,19 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
     "node_modules/date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "babel-runtime": "^6.26.0",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.2.0",
-    "date-fns": "^1.29.0",
+    "date-fns": "^2.30.0",
     "eslint-config-react-app": "^7.0.1",
     "graphql": "^14.7.0",
     "graphql-tag": "^2.8.0",

--- a/client/src/components/Flags/Flag.jsx
+++ b/client/src/components/Flags/Flag.jsx
@@ -4,6 +4,7 @@ import capitalize from 'lodash/capitalize'
 import cn from 'classnames'
 
 import { getIntl } from 'services'
+import { format } from 'date-fns'
 
 const flagMeta = {
   duplicate: {
@@ -40,7 +41,12 @@ const Flag = ({ flag, withlabel, style, ...otherProps }) => {
       {...otherProps}
     >
       <i className="material-icons">{flagMeta[flag.type].icon}</i>
-      {withlabel && <span className="label">{capitalize(intl(flag.type))}</span>}
+      {withlabel && (
+        <span className="label">
+          {capitalize(intl(flag.type))}{' '}
+          {flag.type === 'certified' && format(new Date(flag.createdAt), 'P')}
+        </span>
+      )}
     </div>
   )
 }
@@ -57,14 +63,14 @@ Flag.translations = {
     outdated: 'outdated',
     incomplete: 'incomplete',
     unanswered: 'unanswered',
-    certified: 'certified'
+    certified: 'certified on'
   },
   fr: {
     duplicate: 'doublon',
     outdated: 'obsolète',
     incomplete: 'incomplète',
     unanswered: 'sans réponse',
-    certified: 'certifiée'
+    certified: 'certifiée le'
   }
 }
 

--- a/client/src/components/Flags/Flag.jsx
+++ b/client/src/components/Flags/Flag.jsx
@@ -43,8 +43,12 @@ const Flag = ({ flag, withlabel, style, ...otherProps }) => {
       <i className="material-icons">{flagMeta[flag.type].icon}</i>
       {withlabel && (
         <span className="label">
-          {capitalize(intl(flag.type))}{' '}
-          {flag.type === 'certified' && format(new Date(flag.createdAt), 'P')}
+          {capitalize(intl(flag.type))}
+          {flag.type === 'certified' &&
+            `
+          ${intl('certifiedAdd')}
+          ${format(new Date(flag.createdAt), 'P')}
+          `}
         </span>
       )}
     </div>
@@ -63,14 +67,16 @@ Flag.translations = {
     outdated: 'outdated',
     incomplete: 'incomplete',
     unanswered: 'unanswered',
-    certified: 'certified on'
+    certified: 'certified',
+    certifiedAdd: ' on '
   },
   fr: {
     duplicate: 'doublon',
     outdated: 'obsolète',
     incomplete: 'incomplète',
     unanswered: 'sans réponse',
-    certified: 'certifiée le'
+    certified: 'certifiée',
+    certifiedAdd: ' le '
   }
 }
 

--- a/client/src/components/Flags/Flags.jsx
+++ b/client/src/components/Flags/Flags.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import clone from 'lodash/clone'
 import find from 'lodash/find'
 import map from 'lodash/map'
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 
 import { getIntl } from 'services'
 
@@ -29,7 +29,7 @@ const Flags = ({ node, withLabels }) => {
         let tooltip
 
         if (withLabels && flag.user) {
-          tooltip = intl('tooltip')(flag.user.name, format(flag.createdAt, 'D MMM YYYY'))
+          tooltip = intl('tooltip')(flag.user.name, format(new Date(flag.createdAt), 'P'))
         } else {
           tooltip = flagIntl(flag.type).toUpperCase()
         }

--- a/client/src/helpers/history.js
+++ b/client/src/helpers/history.js
@@ -1,8 +1,5 @@
 import compact from 'lodash/compact'
-import subMonths from 'date-fns/sub_months'
-import differenceInMilliseconds from 'date-fns/difference_in_milliseconds'
-import distanceInWordsToNow from 'date-fns/distance_in_words_to_now'
-import format from 'date-fns/format'
+import { format, formatDistanceToNow, differenceInMilliseconds, subMonths } from 'date-fns'
 
 import { markdown } from 'services'
 
@@ -84,12 +81,13 @@ export const formatHistoryAction = (historyAction, options = { relative: true })
 
   const monthOld = subMonths(new Date(), 1)
 
+  const createdAtDate = new Date(createdAt)
   const date =
-    differenceInMilliseconds(createdAt, monthOld) > 0
-      ? distanceInWordsToNow(createdAt, {
+    differenceInMilliseconds(createdAtDate, monthOld) > 0
+      ? formatDistanceToNow(createdAtDate, {
           addSuffix: true
         })
-      : format(createdAt, 'D MMM YYYY, HH:mm')
+      : format(createdAtDate, 'Pp')
 
   return {
     date,

--- a/client/src/scenes/App/App.jsx
+++ b/client/src/scenes/App/App.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Helmet } from 'react-helmet'
+import { setDefaultOptions } from 'date-fns'
+import { enUS, fr } from 'date-fns/locale'
 
 import { ConfigurationProvider, AuthProvider, UserProvider } from 'contexts'
-
 import { AlertStack, AlertProvider } from 'components'
+import { getNavigatorLanguage } from 'helpers'
 
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
@@ -11,6 +13,10 @@ import Footer from './components/Footer'
 import AppBody from './AppBody'
 
 import 'styles'
+
+setDefaultOptions({
+  locale: getNavigatorLanguage() === 'en' ? enUS : fr
+})
 
 const App = () => (
   <div className="app theme">

--- a/client/src/scenes/Question/Question.container.js
+++ b/client/src/scenes/Question/Question.container.js
@@ -4,10 +4,10 @@ import { query } from 'services/apollo'
 
 import { withError } from 'components'
 
-import { getNode } from './queries'
+import { GET_NODE } from './queries'
 
 export const withNode = compose(
-  query(getNode, {
+  query(GET_NODE, {
     skip: props => !props.match.params.slug,
     variables: props => ({ id: routing.getUIDFromSlug(props.match) })
   }),

--- a/client/src/scenes/Question/queries.js
+++ b/client/src/scenes/Question/queries.js
@@ -24,6 +24,7 @@ export const zNodeFragment = `
     id
     content
     language
+    certified
     translation {
       language
       text

--- a/client/src/scenes/Question/queries.js
+++ b/client/src/scenes/Question/queries.js
@@ -59,6 +59,12 @@ export const zNodeFragment = `
       name
     }
   }
+  history {
+    id
+    meta
+    action
+    model
+  }
 `
 
 export const getNode = gql`

--- a/client/src/scenes/Question/queries.js
+++ b/client/src/scenes/Question/queries.js
@@ -68,8 +68,8 @@ export const zNodeFragment = `
   }
 `
 
-export const getNode = gql`
-  query($id: ID!) {
+export const GET_NODE = gql`
+  query getNode($id: ID!) {
     zNode(where: { id: $id }) {
       ${zNodeFragment}
     }

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -31,8 +31,6 @@ const Read = ({ history, match, zNode, loading }) => {
   const [removeFlag] = useMutation(REMOVE_FLAG)
   const [incrementViewsCounter] = useMutation(INCREMENT_VIEWS_COUNTER)
 
-  const certified = zNode?.flags.find(flag => flag.type === 'certified')
-
   const originalQuestionLanguage = zNode?.question.language
   const navigatorLanguage = getNavigatorLanguage()
 
@@ -116,26 +114,17 @@ const Read = ({ history, match, zNode, loading }) => {
             </div>
             {zNode.tags.length > 0 && <Tags tags={zNode.tags} />}
           </div>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
-              <Flags node={zNode} withLabels={true} />
-              <Views value={zNode.question.views} />
-              <Share node={zNode} />
-              {zNode.question.language && (
-                <LanguageDropdown
-                  onLanguageChanged={translate}
-                  originalLanguage={originalQuestionLanguage}
-                  primary={isTranslated}
-                  link={!isTranslated}
-                />
-              )}
-            </div>
-            {certified && (
-              <p className="small-text">
-                {intl('certified')} <b>{format(certified.createdAt, 'D MMM YYYY')}</b>
-              </p>
-            )}
-          </div>
+          <Flags node={zNode} withLabels={true} />
+          <Views value={zNode.question.views} />
+          <Share node={zNode} />
+          {zNode.question.language && (
+            <LanguageDropdown
+              onLanguageChanged={translate}
+              originalLanguage={originalQuestionLanguage}
+              primary={isTranslated}
+              link={!isTranslated}
+            />
+          )}
         </CardTitle>
         <CardText>
           {zNode.answer ? (

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -72,9 +72,12 @@ const Read = ({ history, match, zNode, loading }) => {
       )
     )
     if (certified && !isSpecialist) {
-      alert(intl('alert'))
+      if (confirm(intl('alert'))) {
+        return history.push(`/q/${match.params.slug}/answer`)
+      }
+    } else {
+      return history.push(`/q/${match.params.slug}/answer`)
     }
-    history.push(`/q/${match.params.slug}/answer`)
   }
 
   /* Redirect to correct URL if old slug used */
@@ -204,7 +207,7 @@ Read.translations = {
     answer: 'Answer the question',
     certified_answer: 'Certified answer',
     alert:
-      'This answer has been certified by a specialist in this field. Are you sure that you want to modify it ?'
+      'This answer has been certified by a specialist in this field.\nAre you sure that you want to modify it ?\nThis version will still be kept'
   },
   fr: {
     menu: {
@@ -221,7 +224,7 @@ Read.translations = {
     answer: 'Répondre à la question',
     certified_answer: 'Réponse certifiée',
     alert:
-      'Cette réponse a été certifiée par une personne spécialisée dans le domaine. Etes-vous sûr de vouloir la modifier ?'
+      'Cette réponse a été certifiée par une personne spécialisée dans le domaine.\nEtes-vous sûr de vouloir la modifier ?\nCelle-ci sera tout de même conservée'
   }
 }
 

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -142,16 +142,21 @@ const Read = ({ history, match, zNode, loading }) => {
           )}
         </CardTitle>
         {zNode.answer?.certified && (
-          <CardText
-            style={{ border: '2px solid #caac00', marginTop: '0.5rem', paddingBottom: '0.5rem' }}
-          >
-            <b>{zNode.answer.certified}</b>
-            <p className="small-text centered">{intl('certified_answer')}</p>
+          <CardText style={{ border: '2px solid #caac00', marginTop: '0.5rem' }}>
+            <p className="small-text centered" style={{ padding: '0.5rem', margin: '0' }}>
+              {intl('certified_answer')}
+            </p>
+            <p style={{ padding: '0.5rem', margin: '0' }}>
+              {markdown.html(zNode.answer.certified)}
+            </p>
           </CardText>
         )}
         <CardText>
           {zNode.answer ? (
             <>
+              <p className="small-text centered" style={{ padding: '0.5rem', margin: '0' }}>
+                {intl('recent_answer')}
+              </p>
               <div style={{ padding: '0.5rem', marginBottom: '0.5rem' }}>
                 {markdown.html(answerContent)}
               </div>
@@ -206,6 +211,7 @@ Read.translations = {
     no_answer: 'No answer yet...',
     answer: 'Answer the question',
     certified_answer: 'Certified answer',
+    recent_answer: 'Latest answer',
     alert:
       'This answer has been certified by a specialist in this field.\nAre you sure that you want to modify it ?\nThis version will still be kept'
   },
@@ -223,6 +229,7 @@ Read.translations = {
     no_answer: 'Pas encore de réponse...',
     answer: 'Répondre à la question',
     certified_answer: 'Réponse certifiée',
+    recent_answer: 'Dernière réponse',
     alert:
       'Cette réponse a été certifiée par une personne spécialisée dans le domaine.\nEtes-vous sûr de vouloir la modifier ?\nCelle-ci sera tout de même conservée'
   }

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -27,7 +27,7 @@ const Read = ({ history, match, zNode, loading }) => {
   const [answerContent, setAnswerContent] = useState('')
   const [isTranslated, setIsTranslated] = useState(false)
 
-  const [createFlag] = useMutation(CREATE_FLAG)
+  const [createFlag] = useMutation(CREATE_FLAG, { refetchQueries: ['getNode'] })
   const [removeFlag] = useMutation(REMOVE_FLAG)
   const [incrementViewsCounter] = useMutation(INCREMENT_VIEWS_COUNTER)
 

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -14,10 +14,10 @@ import { Button, Flags, Loading, Tags } from 'components'
 import Card, { CardText, CardTitle } from 'components/Card'
 import Dropdown, { DropdownItem } from 'components/Dropdown'
 
-import { format } from 'date-fns'
 import { getNavigatorLanguage, handleTranslation } from 'helpers'
 import { ActionMenu } from '../../components'
 import { FlagsDropdown, History, LanguageDropdown, Meta, Share, Sources, Views } from './components'
+import { useUser } from 'contexts'
 
 const Read = ({ history, match, zNode, loading }) => {
   const [loaded, setLoaded] = useState(false)
@@ -30,6 +30,8 @@ const Read = ({ history, match, zNode, loading }) => {
   const [createFlag] = useMutation(CREATE_FLAG)
   const [removeFlag] = useMutation(REMOVE_FLAG)
   const [incrementViewsCounter] = useMutation(INCREMENT_VIEWS_COUNTER)
+
+  const user = useUser()
 
   const originalQuestionLanguage = zNode?.question.language
   const navigatorLanguage = getNavigatorLanguage()
@@ -62,6 +64,19 @@ const Read = ({ history, match, zNode, loading }) => {
     return <NotFound />
   }
 
+  const preventAnswerEdit = () => {
+    const certified = zNode?.flags.find(flag => flag.type === 'certified')
+    const isSpecialist = Boolean(
+      user.specialties.filter(specialty =>
+        zNode.tags.some(tag => specialty.name === tag.label.name)
+      )
+    )
+    if (certified && !isSpecialist) {
+      alert(intl('alert'))
+    }
+    history.push(`/q/${match.params.slug}/answer`)
+  }
+
   /* Redirect to correct URL if old slug used */
   const correctSlug = zNode.question.slug + '-' + zNode.id
   if (match.params.slug !== correctSlug) {
@@ -83,10 +98,7 @@ const Read = ({ history, match, zNode, loading }) => {
           <DropdownItem icon="edit" onClick={() => history.push(`/q/${match.params.slug}/edit`)}>
             {intl('menu.edit.question')}
           </DropdownItem>
-          <DropdownItem
-            icon="question_answer"
-            onClick={() => history.push(`/q/${match.params.slug}/answer`)}
-          >
+          <DropdownItem icon="question_answer" onClick={preventAnswerEdit}>
             {intl('menu.edit.answer')}
           </DropdownItem>
         </Dropdown>
@@ -181,7 +193,8 @@ Read.translations = {
     certified: 'Certified on',
     auto_translated: 'Automatic translation',
     no_answer: 'No answer yet...',
-    answer: 'Answer the question'
+    answer: 'Answer the question',
+    alert: ''
   },
   fr: {
     menu: {
@@ -195,7 +208,8 @@ Read.translations = {
     certified: 'Certifiée le',
     auto_translated: 'Traduction automatique',
     no_answer: 'Pas encore de réponse...',
-    answer: 'Répondre à la question'
+    answer: 'Répondre à la question',
+    alert: 'Cette réponse a été certifiée par une personne spécialisée dans le domaine. '
   }
 }
 

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -14,6 +14,7 @@ import { Button, Flags, Loading, Tags } from 'components'
 import Card, { CardText, CardTitle } from 'components/Card'
 import Dropdown, { DropdownItem } from 'components/Dropdown'
 
+import { format } from 'date-fns'
 import { getNavigatorLanguage, handleTranslation } from 'helpers'
 import { ActionMenu } from '../../components'
 import { FlagsDropdown, History, LanguageDropdown, Meta, Share, Sources, Views } from './components'
@@ -29,6 +30,9 @@ const Read = ({ history, match, zNode, loading }) => {
   const [createFlag] = useMutation(CREATE_FLAG)
   const [removeFlag] = useMutation(REMOVE_FLAG)
   const [incrementViewsCounter] = useMutation(INCREMENT_VIEWS_COUNTER)
+  console.log(zNode)
+
+  const certified = zNode.flags.find(flag => flag.type === 'certified')
 
   const originalQuestionLanguage = zNode?.question.language
   const navigatorLanguage = getNavigatorLanguage()
@@ -113,17 +117,26 @@ const Read = ({ history, match, zNode, loading }) => {
             </div>
             {zNode.tags.length > 0 && <Tags tags={zNode.tags} />}
           </div>
-          <Flags node={zNode} withLabels={true} />
-          <Views value={zNode.question.views} />
-          <Share node={zNode} />
-          {zNode.question.language && (
-            <LanguageDropdown
-              onLanguageChanged={translate}
-              originalLanguage={originalQuestionLanguage}
-              primary={isTranslated}
-              link={!isTranslated}
-            />
-          )}
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+              <Flags node={zNode} withLabels={true} />
+              <Views value={zNode.question.views} />
+              <Share node={zNode} />
+              {zNode.question.language && (
+                <LanguageDropdown
+                  onLanguageChanged={translate}
+                  originalLanguage={originalQuestionLanguage}
+                  primary={isTranslated}
+                  link={!isTranslated}
+                />
+              )}
+            </div>
+            {certified && (
+              <p className="small-text">
+                {intl('certified')} <b>{format(certified.createdAt, 'D MMM YYYY')}</b>
+              </p>
+            )}
+          </div>
         </CardTitle>
         <CardText>
           {zNode.answer ? (
@@ -177,6 +190,7 @@ Read.translations = {
         answer: 'Answer'
       }
     },
+    certified: 'Certified on',
     auto_translated: 'Automatic translation',
     no_answer: 'No answer yet...',
     answer: 'Answer the question'
@@ -190,6 +204,7 @@ Read.translations = {
         answer: 'Réponse'
       }
     },
+    certified: 'Certifiée le',
     auto_translated: 'Traduction automatique',
     no_answer: 'Pas encore de réponse...',
     answer: 'Répondre à la question'

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -66,10 +66,8 @@ const Read = ({ history, match, zNode, loading }) => {
 
   const preventAnswerEdit = () => {
     const certified = zNode?.flags.find(flag => flag.type === 'certified')
-    const isSpecialist = Boolean(
-      user.specialties.filter(specialty =>
-        zNode.tags.some(tag => specialty.name === tag.label.name)
-      )
+    const isSpecialist = user.specialties.some(specialty =>
+      zNode.tags.some(tag => specialty.name === tag.label.name)
     )
     if (certified && !isSpecialist) {
       if (window.confirm(intl('alert'))) {

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -146,17 +146,19 @@ const Read = ({ history, match, zNode, loading }) => {
             <p className="small-text centered" style={{ padding: '0.5rem', margin: '0' }}>
               {intl('certified_answer')}
             </p>
-            <p style={{ padding: '0.5rem', margin: '0' }}>
+            <div style={{ padding: '0.5rem', margin: '0' }}>
               {markdown.html(zNode.answer.certified)}
-            </p>
+            </div>
           </CardText>
         )}
         <CardText>
           {zNode.answer ? (
             <>
-              <p className="small-text centered" style={{ padding: '0.5rem', margin: '0' }}>
-                {intl('recent_answer')}
-              </p>
+              {zNode.answer.certified && (
+                <p className="small-text centered" style={{ padding: '0.5rem', margin: '0' }}>
+                  {intl('recent_answer')}
+                </p>
+              )}
               <div style={{ padding: '0.5rem', marginBottom: '0.5rem' }}>
                 {markdown.html(answerContent)}
               </div>

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -138,6 +138,14 @@ const Read = ({ history, match, zNode, loading }) => {
             />
           )}
         </CardTitle>
+        {zNode.answer?.certified && (
+          <CardText
+            style={{ border: '2px solid #caac00', marginTop: '0.5rem', paddingBottom: '0.5rem' }}
+          >
+            <b>{zNode.answer.certified}</b>
+            <p className="small-text centered">{intl('certified_answer')}</p>
+          </CardText>
+        )}
         <CardText>
           {zNode.answer ? (
             <>
@@ -194,7 +202,9 @@ Read.translations = {
     auto_translated: 'Automatic translation',
     no_answer: 'No answer yet...',
     answer: 'Answer the question',
-    alert: ''
+    certified_answer: 'Certified answer',
+    alert:
+      'This answer has been certified by a specialist in this field. Are you sure that you want to modify it ?'
   },
   fr: {
     menu: {
@@ -209,7 +219,9 @@ Read.translations = {
     auto_translated: 'Traduction automatique',
     no_answer: 'Pas encore de réponse...',
     answer: 'Répondre à la question',
-    alert: 'Cette réponse a été certifiée par une personne spécialisée dans le domaine. '
+    certified_answer: 'Réponse certifiée',
+    alert:
+      'Cette réponse a été certifiée par une personne spécialisée dans le domaine. Etes-vous sûr de vouloir la modifier ?'
   }
 }
 

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -30,9 +30,8 @@ const Read = ({ history, match, zNode, loading }) => {
   const [createFlag] = useMutation(CREATE_FLAG)
   const [removeFlag] = useMutation(REMOVE_FLAG)
   const [incrementViewsCounter] = useMutation(INCREMENT_VIEWS_COUNTER)
-  console.log(zNode)
 
-  const certified = zNode.flags.find(flag => flag.type === 'certified')
+  const certified = zNode?.flags.find(flag => flag.type === 'certified')
 
   const originalQuestionLanguage = zNode?.question.language
   const navigatorLanguage = getNavigatorLanguage()

--- a/client/src/scenes/Question/scenes/Read/Read.jsx
+++ b/client/src/scenes/Question/scenes/Read/Read.jsx
@@ -72,7 +72,7 @@ const Read = ({ history, match, zNode, loading }) => {
       )
     )
     if (certified && !isSpecialist) {
-      if (confirm(intl('alert'))) {
+      if (window.confirm(intl('alert'))) {
         return history.push(`/q/${match.params.slug}/answer`)
       }
     } else {

--- a/client/src/scenes/Question/scenes/Read/components/Meta/Meta.jsx
+++ b/client/src/scenes/Question/scenes/Read/components/Meta/Meta.jsx
@@ -21,7 +21,7 @@ const Meta = ({ node }) => {
         <div>
           {intl('asked')} {node.question.user.name}
           <br />
-          {format(node.question.createdAt, 'D MMM YYYY')}
+          {format(new Date(node.question.createdAt), 'P')}
         </div>
       </div>
       {node.answer && (
@@ -29,7 +29,7 @@ const Meta = ({ node }) => {
           <div>
             {intl('answered')} {node.answer.user.name}
             <br />
-            {format(node.answer.createdAt, 'D MMM YYYY')}
+            {format(new Date(node.answer.createdAt), 'P')}
           </div>
           <Avatar
             image={node.answer.user.picture}

--- a/client/src/scenes/Settings/helpers.js
+++ b/client/src/scenes/Settings/helpers.js
@@ -27,12 +27,17 @@ export const reducer = (state, action) => {
   }
 }
 
-export const synonymsToList = synonyms =>
-  (synonyms || []).map(({ objectID, synonyms }, id) => ({
+export const synonymsToList = synonyms => {
+  if (!synonyms) {
+    return []
+  }
+  const actualSynonyms = Array.isArray(synonyms) ? synonyms : [synonyms]
+  return actualSynonyms.map(({ objectID, synonyms }, id) => ({
     id,
     key: objectID,
     value: synonyms.join(', ')
   }))
+}
 
 export const listToSynonyms = list =>
   list.map(item => ({

--- a/e2e/client.test.js
+++ b/e2e/client.test.js
@@ -718,7 +718,7 @@ test('Should not be able to add a certified flag to a question not in my special
   await expect(page.locator('a').filter({ hasText: 'verifiedcertifiée' })).toBeHidden()
 })
 
-test('Should remove the certified flag after modifying an answer', async ({ page }) => {
+test.only('Should remove the certified flag after modifying an answer', async ({ page }) => {
   await setUser(page)
   await createQuestionWithFlag(prisma, tag.id, tempUser)
   await page.goto('/')
@@ -727,6 +727,7 @@ test('Should remove the certified flag after modifying an answer', async ({ page
   await openCard.click()
   await expect(page.getByText('verifiedCertifiée')).toBeVisible()
   await page.getByRole('button', { name: 'Modifier' }).hover()
+  page.on('dialog', dialog => dialog.accept())
   await page
     .locator('a')
     .filter({ hasText: 'Réponse' })

--- a/e2e/client.test.js
+++ b/e2e/client.test.js
@@ -718,7 +718,7 @@ test('Should not be able to add a certified flag to a question not in my special
   await expect(page.locator('a').filter({ hasText: 'verifiedcertifiée' })).toBeHidden()
 })
 
-test.only('Should remove the certified flag after modifying an answer', async ({ page }) => {
+test('Should remove the certified flag after modifying an answer', async ({ page }) => {
   await setUser(page)
   await createQuestionWithFlag(prisma, tag.id, tempUser)
   await page.goto('/')

--- a/e2e/client.test.js
+++ b/e2e/client.test.js
@@ -635,7 +635,7 @@ test('Should not be able to add a certified flag to an unanswered question', asy
   await expect(page.locator('a').filter({ hasText: 'verifiedcertifiée' })).toBeHidden()
 })
 
-test('Should be able to add a certified flag for a question of my specialty', async ({ page }) => {
+test('Should be able to add a certified flag to a question of my specialty', async ({ page }) => {
   await page.goto('/')
   await page
     .locator('button', { hasText: 'Nouvelle question' })
@@ -653,17 +653,21 @@ test('Should be able to add a certified flag for a question of my specialty', as
   await page.locator('textarea').click()
   await page.locator('textarea').fill('Ceci est une réponse')
   await page.locator('button', { hasText: 'Envoyer la réponse' }).click()
-  await page.getByRole('button', { name: 'flag Signaler ...' }).hover()
+  await page.getByRole('button', { name: 'Modifier' }).hover()
   await page
     .locator('a')
-    .filter({ hasText: 'verifiedcertifiée' })
+    .filter({ hasText: 'Réponse' })
     .click()
+  await page.locator('textarea').click()
+  await page.locator('textarea').fill('Ceci est une réponse différente')
+  await page.locator('button', { hasText: 'Enregistrer la réponse' }).click()
   await page.waitForTimeout(1000)
-  await page.goto('/')
-  await expect(page.getByText('verified')).toBeVisible()
+  await expect(page.getByText('Ceci est une réponse différente')).toBeVisible()
+  await expect(page.getByText('Réponse certifiée')).toBeHidden()
+  await expect(page.getByText('verified').nth(1)).toBeVisible()
 })
 
-test('Should not be able to add a certified flag for a question not in my specialty', async ({
+test('Should not be able to add a certified flag to a question not in my specialty', async ({
   page
 }) => {
   await page.goto('/')
@@ -703,6 +707,9 @@ test('Should remove the certified flag after modifying an answer', async ({ page
   await page.locator('textarea').fill('Ceci est une réponse différente')
   await page.locator('button', { hasText: 'Enregistrer la réponse' }).click()
   await page.waitForTimeout(1000)
+  await expect(page.locator("p:near(:text('Réponse certifiée'))")).toHaveText(
+    'Ceci est une réponse'
+  )
   await expect(page.getByText('verifiedCertifiée')).toBeHidden()
 })
 

--- a/server/prisma/datamodel.graphql
+++ b/server/prisma/datamodel.graphql
@@ -37,6 +37,7 @@ type Answer {
   content: String!
   language: String!
   translation: Translation
+  certified: String
 
   sources: [Source!]! @relation(name: "AnswerSources", onDelete: CASCADE, link: TABLE)
 

--- a/server/src/generated/prisma.graphql
+++ b/server/src/generated/prisma.graphql
@@ -51,6 +51,7 @@ type Answer {
   content: String!
   language: String!
   translation: Translation
+  certified: String
   sources(
     where: SourceWhereInput
     orderBy: SourceOrderByInput
@@ -77,6 +78,7 @@ input AnswerCreateInput {
   content: String!
   language: String!
   translation: TranslationCreateOneInput
+  certified: String
   sources: SourceCreateManyWithoutAnswerInput
   node: ZNodeCreateOneWithoutAnswerInput!
   user: UserCreateOneWithoutAnswersInput!
@@ -102,6 +104,7 @@ input AnswerCreateWithoutNodeInput {
   content: String!
   language: String!
   translation: TranslationCreateOneInput
+  certified: String
   sources: SourceCreateManyWithoutAnswerInput
   user: UserCreateOneWithoutAnswersInput!
 }
@@ -111,6 +114,7 @@ input AnswerCreateWithoutSourcesInput {
   content: String!
   language: String!
   translation: TranslationCreateOneInput
+  certified: String
   node: ZNodeCreateOneWithoutAnswerInput!
   user: UserCreateOneWithoutAnswersInput!
 }
@@ -120,6 +124,7 @@ input AnswerCreateWithoutUserInput {
   content: String!
   language: String!
   translation: TranslationCreateOneInput
+  certified: String
   sources: SourceCreateManyWithoutAnswerInput
   node: ZNodeCreateOneWithoutAnswerInput!
 }
@@ -136,6 +141,8 @@ enum AnswerOrderByInput {
   content_DESC
   language_ASC
   language_DESC
+  certified_ASC
+  certified_DESC
   createdAt_ASC
   createdAt_DESC
   updatedAt_ASC
@@ -146,6 +153,7 @@ type AnswerPreviousValues {
   id: ID!
   content: String!
   language: String!
+  certified: String
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -193,6 +201,20 @@ input AnswerScalarWhereInput {
   language_not_starts_with: String
   language_ends_with: String
   language_not_ends_with: String
+  certified: String
+  certified_not: String
+  certified_in: [String!]
+  certified_not_in: [String!]
+  certified_lt: String
+  certified_lte: String
+  certified_gt: String
+  certified_gte: String
+  certified_contains: String
+  certified_not_contains: String
+  certified_starts_with: String
+  certified_not_starts_with: String
+  certified_ends_with: String
+  certified_not_ends_with: String
   createdAt: DateTime
   createdAt_not: DateTime
   createdAt_in: [DateTime!]
@@ -236,6 +258,7 @@ input AnswerUpdateInput {
   content: String
   language: String
   translation: TranslationUpdateOneInput
+  certified: String
   sources: SourceUpdateManyWithoutAnswerInput
   node: ZNodeUpdateOneRequiredWithoutAnswerInput
   user: UserUpdateOneRequiredWithoutAnswersInput
@@ -244,11 +267,13 @@ input AnswerUpdateInput {
 input AnswerUpdateManyDataInput {
   content: String
   language: String
+  certified: String
 }
 
 input AnswerUpdateManyMutationInput {
   content: String
   language: String
+  certified: String
 }
 
 input AnswerUpdateManyWithoutUserInput {
@@ -288,6 +313,7 @@ input AnswerUpdateWithoutNodeDataInput {
   content: String
   language: String
   translation: TranslationUpdateOneInput
+  certified: String
   sources: SourceUpdateManyWithoutAnswerInput
   user: UserUpdateOneRequiredWithoutAnswersInput
 }
@@ -296,6 +322,7 @@ input AnswerUpdateWithoutSourcesDataInput {
   content: String
   language: String
   translation: TranslationUpdateOneInput
+  certified: String
   node: ZNodeUpdateOneRequiredWithoutAnswerInput
   user: UserUpdateOneRequiredWithoutAnswersInput
 }
@@ -304,6 +331,7 @@ input AnswerUpdateWithoutUserDataInput {
   content: String
   language: String
   translation: TranslationUpdateOneInput
+  certified: String
   sources: SourceUpdateManyWithoutAnswerInput
   node: ZNodeUpdateOneRequiredWithoutAnswerInput
 }
@@ -373,6 +401,20 @@ input AnswerWhereInput {
   language_ends_with: String
   language_not_ends_with: String
   translation: TranslationWhereInput
+  certified: String
+  certified_not: String
+  certified_in: [String!]
+  certified_not_in: [String!]
+  certified_lt: String
+  certified_lte: String
+  certified_gt: String
+  certified_gte: String
+  certified_contains: String
+  certified_not_contains: String
+  certified_starts_with: String
+  certified_not_starts_with: String
+  certified_ends_with: String
+  certified_not_ends_with: String
   sources_every: SourceWhereInput
   sources_some: SourceWhereInput
   sources_none: SourceWhereInput

--- a/server/src/helpers/certified.js
+++ b/server/src/helpers/certified.js
@@ -31,6 +31,7 @@ const addCertifiedFlagWhenSpecialist = async (history, user, node, nodeId, ctx) 
 const refreshCertifiedFlag = async (history, answer, user, ctx) => {
   const certifiedFlag = answer.node.flags.find(flag => flag.type === type)
   let isCertified = Boolean(certifiedFlag)
+  const wasCertified = isCertified
   const tags = answer.node.tags.map(tag => tag.label.id)
   const specialties = user.specialties
   const isUserSpecialist = Boolean(specialties.find(specialty => tags.includes(specialty.id)))
@@ -42,7 +43,7 @@ const refreshCertifiedFlag = async (history, answer, user, ctx) => {
     await deleteFlagAndUpdateHistoryAndAlgolia(history, type, ctx, answer.node.id, certifiedFlag.id)
     isCertified = false
   }
-  return isCertified
+  return { isCertified, wasCertified }
 }
 
 module.exports = {

--- a/server/src/helpers/certified.js
+++ b/server/src/helpers/certified.js
@@ -30,15 +30,19 @@ const addCertifiedFlagWhenSpecialist = async (history, user, node, nodeId, ctx) 
 
 const refreshCertifiedFlag = async (history, answer, user, ctx) => {
   const certifiedFlag = answer.node.flags.find(flag => flag.type === type)
+  let isCertified = Boolean(certifiedFlag)
   const tags = answer.node.tags.map(tag => tag.label.id)
   const specialties = user.specialties
   const isUserSpecialist = Boolean(specialties.find(specialty => tags.includes(specialty.id)))
 
   if (isUserSpecialist && !certifiedFlag) {
     await createFlagAndUpdateHistoryAndAlgolia(history, type, ctx, answer.node.id, user.id)
+    isCertified = true
   } else if (!isUserSpecialist && certifiedFlag) {
     await deleteFlagAndUpdateHistoryAndAlgolia(history, type, ctx, answer.node.id, certifiedFlag.id)
+    isCertified = false
   }
+  return isCertified
 }
 
 module.exports = {

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -215,7 +215,7 @@ module.exports = {
 
       await Promise.all([...mutationsToAdd, ...mutationsToUpdate, ...mutationsToRemove])
 
-      await refreshCertifiedFlag(history, answer, user, ctx)
+      const isCertified = await refreshCertifiedFlag(history, answer, user, ctx)
 
       const clean = sources => sources.map(s => ({ label: s.label, url: s.url }))
 
@@ -233,8 +233,10 @@ module.exports = {
 
       const certifiedFlag = Boolean(answer.node.flags?.find(flag => flag.type === 'certified'))
       let certifiedContent = ''
-      if (certifiedFlag) {
+      if (certifiedFlag && !isCertified) {
         certifiedContent = previousContent
+      } else if (certifiedFlag && isCertified) {
+        certifiedContent = ''
       }
 
       const { language, translation } = await storeTranslation(content)

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -237,8 +237,6 @@ module.exports = {
         certifiedContent = previousContent
       } else if (!wasCertified && !isCertified && answer.certified) {
         certifiedContent = answer.certified
-      } else if (isCertified && answer.certified) {
-        certifiedContent = ''
       }
 
       const { language, translation } = await storeTranslation(content)

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -124,6 +124,7 @@ module.exports = {
         {
           id
           content
+          certified
           sources {
             id
             label
@@ -215,7 +216,7 @@ module.exports = {
 
       await Promise.all([...mutationsToAdd, ...mutationsToUpdate, ...mutationsToRemove])
 
-      const isCertified = await refreshCertifiedFlag(history, answer, user, ctx)
+      const { isCertified, wasCertified } = await refreshCertifiedFlag(history, answer, user, ctx)
 
       const clean = sources => sources.map(s => ({ label: s.label, url: s.url }))
 
@@ -231,11 +232,12 @@ module.exports = {
         meta.content = content
       }
 
-      const certifiedFlag = Boolean(answer.node.flags?.find(flag => flag.type === 'certified'))
       let certifiedContent = ''
-      if (certifiedFlag && !isCertified) {
+      if (wasCertified && !isCertified) {
         certifiedContent = previousContent
-      } else if (certifiedFlag && isCertified) {
+      } else if (!wasCertified && !isCertified && answer.certified) {
+        certifiedContent = answer.certified
+      } else if (isCertified && answer.certified) {
         certifiedContent = ''
       }
 

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -231,11 +231,18 @@ module.exports = {
         meta.content = content
       }
 
+      const certifiedFlag = Boolean(answer.node.flags?.find(flag => flag.type === 'certified'))
+      let certifiedContent = ''
+      if (certifiedFlag) {
+        certifiedContent = previousContent
+      }
+
       const { language, translation } = await storeTranslation(content)
 
       const updateAnswerData = {
         content,
-        language
+        language,
+        certified: certifiedContent
       }
 
       if (translation) {

--- a/server/src/resolvers/flag.js
+++ b/server/src/resolvers/flag.js
@@ -14,6 +14,25 @@ module.exports = {
         await createFlagAndUpdateHistoryAndAlgolia(history, type, ctx, nodeId, ctxUser(ctx).id)
       }
 
+      if (type === 'certified') {
+        let certified = ''
+        const node = await ctx.prisma.query.zNode(
+          {
+            where: { id: nodeId }
+          },
+          `{
+            id
+            answer {
+              id
+            }
+          }`
+        )
+        await ctx.prisma.mutation.updateAnswer({
+          where: { id: node.answer.id },
+          data: { certified }
+        })
+      }
+
       return ctx.prisma.query.zNode({ where: { id: nodeId } }, info)
     },
     removeFlag: async (_, { type, nodeId }, ctx, info) => {

--- a/server/src/resolvers/flag.js
+++ b/server/src/resolvers/flag.js
@@ -15,7 +15,6 @@ module.exports = {
       }
 
       if (type === 'certified') {
-        let certified = ''
         const node = await ctx.prisma.query.zNode(
           {
             where: { id: nodeId }
@@ -29,7 +28,7 @@ module.exports = {
         )
         await ctx.prisma.mutation.updateAnswer({
           where: { id: node.answer.id },
-          data: { certified }
+          data: { certified: '' }
         })
       }
 


### PR DESCRIPTION
This ensures that the latest certified answer is always accessible, even after the answer has been modified.

![image](https://github.com/zenika-open-source/FAQ/assets/1656170/3977a003-12a0-4d32-98e7-32c1cf05a5eb)

Also:
- Adds a confirm modal when editing a certified answer
- Adds the date of certification to the Certified flag
- Upgrade date-fns
- Fixes Algolia synonyms in some cases
