### PR TITLE
:sparkles: add flag when a question is translated

### DIFF
--- a/client/src/components/Flags/Flag.jsx
+++ b/client/src/components/Flags/Flag.jsx
@@ -26,6 +26,10 @@ const flagMeta = {
     icon: 'verified',
     color: '#caac00',
   },
+  translated: {
+    icon: 'translate',
+    color: '#0e00cc',
+  },
 }
 
 const Flag = ({ flag, withlabel, style, ...otherProps }) => {
@@ -68,6 +72,7 @@ Flag.translations = {
     unanswered: 'unanswered',
     certified: 'certified',
     certifiedAdd: ' on ',
+    translated: 'translated',
   },
   fr: {
     duplicate: 'doublon',
@@ -76,6 +81,7 @@ Flag.translations = {
     unanswered: 'sans réponse',
     certified: 'certifiée',
     certifiedAdd: ' le ',
+    translated: 'traduit',
   },
 }
 

--- a/server/src/resolvers/question.js
+++ b/server/src/resolvers/question.js
@@ -61,7 +61,8 @@ module.exports = {
                 {
                   type: 'unanswered',
                   user: { connect: { id: ctxUser(ctx).id } }
-                }, {
+                },
+                {
                   type: 'translated',
                   user: { connect: { id: ctxUser(ctx).id } }
                 }
@@ -196,7 +197,13 @@ module.exports = {
       }
 
       if (translation) {
-        await createFlagAndUpdateHistoryAndAlgolia(history, 'translated', ctx, node.id, ctxUser(ctx).id)
+        await createFlagAndUpdateHistoryAndAlgolia(
+          history,
+          'translated',
+          ctx,
+          node.id,
+          ctxUser(ctx).id
+        )
       }
 
       await ctx.prisma.mutation.updateQuestion({


### PR DESCRIPTION
Automatically add a flag to a question when there is a translation available  
![image](https://github.com/zenika-open-source/FAQ/assets/77327446/084fe5e2-50e2-447d-add4-7930ce3cc006)
![image](https://github.com/zenika-open-source/FAQ/assets/77327446/6608e28b-6730-47f3-b1b1-05a844c04083)
